### PR TITLE
Fix src directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
         name='grafanatools',
         version='0.0.1',
         packages=find_packages(where='src'),
-        package_dir={'grafanatools': 'src/grafanatools'},
+        package_dir={'': 'src'},
         url='https://github.com/callumstew/grafanatools',
         author='Callum Stewart',
         author_email='callum.stewart@gmail.com',


### PR DESCRIPTION
This fixes the source dir when installing the package from URL, e.g.
```bash
pip install -e git+https://github.com/callumstew/grafanatools
```
Otherwise scripts need to import `src.grafanatools` instead of `grafanatools`.